### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,8 @@
 fixtures:
   repositories:
     common: "git://github.com/simp/pupmod-simp-common"
-    concat: "git://github.com/simp/pupmod-simp-concat"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
+    simpcat: "git://github.com/simp/pupmod-simp-concat"
     rsync: "git://github.com/simp/pupmod-simp-rsync"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
   symlinks:

--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -3,6 +3,7 @@ fixtures:
   symlinks:
     sudo: "#{source_dir}"
     common: "#{source_dir}/../common"
-    concat: "#{source_dir}/../concat"
+    simplib: "#{source_dir}/../simplib"
+    simpcat: "#{source_dir}/../simpcat"
     rsync: "#{source_dir}/../rsync"
     stdlib: "#{source_dir}/../stdlib"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,5 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-variables_not_enclosed-check
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,68 +1,54 @@
 ---
 language: ruby
 cache: bundler
-fast_finish: true
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
+#  - 1.8.7  # bombs out on mime-types
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
-###script: bundle exec rake test
 script:
     - 'bundle exec rake validate'
     - 'bundle exec rake lint'
     - 'bundle exec rake spec'
+# NOTE: `:environmentpath` was not supported before Puppet 3.5
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 4.0.0"
-  - PUPPET_VERSION="~> 4.1.0"
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: 1.8.7
     - rvm: 2.1.0
     - rvm: 2.2.1
-    - env:
-      - PUPPET_VERSION="~> 2.7.0"
-      - PUPPET_VERSION="~> 3.2.0"
-      - PUPPET_VERSION="~> 3.3.0"
-      - PUPPET_VERSION="~> 3.4.0"
-      - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 4.0.0"
-      - PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
 
   # Ruby 1.9.3
   - rvm: 1.9.3
@@ -71,46 +57,15 @@ matrix:
   # Ruby 2.0.0
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
 
   # Ruby 2.1.0
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.6.0"
 
   # Ruby 2.2.1
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 2.7.0"
-  # - No Ruby 2.2 for ~>3.X: https://tickets.puppetlabs.com/browse/PUP-3796
+    env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -8,17 +8,17 @@ gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[,
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem "rake"
+  gem 'rake'
   gem 'puppet', puppetversion
-  gem "rspec", '< 3.2.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem "puppetlabs_spec_helper"
-  gem "metadata-json-lint"
-  gem "simp-rspec-puppet-facts"
+  gem 'rspec', '< 3.2.0'
+  gem 'rspec-puppet'
+  gem 'puppetlabs_spec_helper'
+  gem 'metadata-json-lint'
+  gem 'simp-rspec-puppet-facts'
 
   # simp-rake-helpers does not suport puppet 2.7.X
   # FIXME: simp-rake-helpers should support Puppet 4.X
-  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first)) &&
+  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".split('.').first)) &&
       ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
       # TODO: fix upstream deps (parallel in simp-rake-helpers)
@@ -28,16 +28,17 @@ group :test do
 end
 
 group :development do
-  gem "travis"
-  gem "travis-lint"
-  gem "vagrant-wrapper"
-  gem "puppet-blacksmith"
-  gem "guard-rake"
+  gem 'travis'
+  gem 'travis-lint'
+  gem 'vagrant-wrapper'
+  gem 'puppet-blacksmith'
+  gem 'guard'
+  gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
 end
 
 group :system_tests do
-  gem "beaker"
-  gem "beaker-rspec"
+  gem 'beaker'
+  gem 'beaker-rspec'
 end

--- a/build/pupmod-sudo.spec
+++ b/build/pupmod-sudo.spec
@@ -1,13 +1,14 @@
 Summary: Sudo Puppet Module
 Name: pupmod-sudo
 Version: 4.1.0
-Release: 2
+Release: 3
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-common >= 4.2.0-0
-Requires: pupmod-concat >= 2.0.0-0
+Requires: pupmod-simplib >= 1.0.0-0
+Requires: pupmod-simpcat >= 2.0.0-0
 Requires: puppet >= 3.3.0
 Requires: puppetlabs-stdlib >= 4.1.0-0.SIMP
 Buildarch: noarch
@@ -56,6 +57,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-3
+- migration to simplib and simpcat (lib/ only)
+
 * Thu Sep 03 2015 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.0-2
 - Removed use of lsb facts.  Updated travis framework to match
   skeleton.

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "tags": [ "simp", "sudo" ],
   "dependencies": [
     {
-      "name": "simp-common",
-      "version_requirement": ">= 4.2.0"
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
     },
     {
-      "name": "simp-concat",
+      "name": "simp-simpcat",
       "version_requirement": ">= 4.0.0"
     },
     {
@@ -23,10 +23,6 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.1.0"
-    },
-    {
-      "name": "simp-simplib",
       "version_requirement": ">= 4.1.0"
     }
   ],


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-sudo`.
SIMP-604 #comment Updated `pupmod-simp-sudo`.