### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Fri Aug 05 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.2-0
 - Updated the user_specification docs and spec.
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,2 +1,2 @@
-Requires: pupmod-simp-simpcat >= 2.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Obsoletes: pupmod-sudo-test >= 0.0.1

--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -41,7 +41,7 @@ define sudo::alias (
 ) {
   include 'sudo'
 
-  concat_fragment { "sudoers+${alias_type}_${name}_${order}.alias":
+  simpcat_fragment { "sudoers+${alias_type}_${name}_${order}.alias":
     content => template('sudo/alias.erb')
   }
 

--- a/manifests/default_entry.pp
+++ b/manifests/default_entry.pp
@@ -56,7 +56,7 @@ define sudo::default_entry (
 ) {
   include 'sudo'
 
-  concat_fragment { "sudoers+$name.default":
+  simpcat_fragment { "sudoers+$name.default":
     content => template('sudo/defaults.erb')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,9 +11,9 @@
 #
 class sudo {
   # This builds a local 'new' sudoers file.
-  $outfile = concat_output('sudoers')
+  $outfile = simpcat_output('sudoers')
 
-  concat_build { 'sudoers':
+  simpcat_build { 'sudoers':
     order  => ['remote_sudoers', '*.alias', '*.default', '*.uspec'],
     target => '/etc/sudoers',
     onlyif => "/usr/sbin/visudo -q -c -f ${outfile}"
@@ -26,7 +26,7 @@ class sudo {
     mode      => '0440',
     backup    => false,
     audit     => content,
-    subscribe => Concat_build['sudoers'],
+    subscribe => Simpcat_build['sudoers'],
     require   => Package['sudo']
   }
 

--- a/manifests/user_specification.pp
+++ b/manifests/user_specification.pp
@@ -56,7 +56,7 @@ define sudo::user_specification (
 ) {
   include 'sudo'
 
-  concat_fragment { "sudoers+$name.uspec":
+  simpcat_fragment { "sudoers+$name.uspec":
     content => template('sudo/uspec.erb')
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-sudo",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "Manage sudo",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/rsync",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,7 +11,7 @@ describe 'sudo' do
       it { should create_class('sudo') }
     
       it do
-        should contain_concat_build('sudoers').with({
+        should contain_simpcat_build('sudoers').with({
           'order' => ['remote_sudoers', '*.alias', '*.default', '*.uspec'],
           'target' => '/etc/sudoers',
           #'onlyif' => Output of concat build
@@ -26,7 +26,7 @@ describe 'sudo' do
           'mode' => '0440',
           'backup' => false,
           'audit' => 'content',
-          'subscribe' => 'Concat_build[sudoers]',
+          'subscribe' => 'Simpcat_build[sudoers]',
           'require' => 'Package[sudo]'
         })
       end

--- a/spec/defines/alias_spec.rb
+++ b/spec/defines/alias_spec.rb
@@ -14,7 +14,7 @@ describe 'sudo::alias' do
   it { should compile.with_all_deps }
 
   it {
-    should contain_concat_fragment('sudoers+user_user_alias_11.alias').with_content(
+    should contain_simpcat_fragment('sudoers+user_user_alias_11.alias').with_content(
       /.*generic comment(\s*|.*)User_Alias(\s*|.*)USER_ALIAS(\s*|.*)millert, mikef.*/
     )
   }

--- a/spec/defines/default_entry_spec.rb
+++ b/spec/defines/default_entry_spec.rb
@@ -9,7 +9,7 @@ describe 'sudo::default_entry' do
   it { should compile.with_all_deps }
 
   it do
-    should create_concat_fragment('sudoers+default_entry_spec.default') \
+    should create_simpcat_fragment('sudoers+default_entry_spec.default') \
       .with_content(/first.*second/)
   end
 end

--- a/spec/defines/user_specification_spec.rb
+++ b/spec/defines/user_specification_spec.rb
@@ -7,7 +7,7 @@ describe 'sudo::user_specification' do
   let(:params) { {:user_list => 'joe, jimbob, %foo', :cmnd => ['ifconfig']} }
 
   it do
-    should contain_concat_fragment('sudoers+user_specification_spec.uspec') \
+    should contain_simpcat_fragment('sudoers+user_specification_spec.uspec') \
       .with_content(/.*joe, jimbob, %foo(\s*|.*)PASSWD.*EXEC.*ifconfig/)
   end
 


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'sudo'
