### PR TITLE
(SIMP-2506) Fix validate cmd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Wed Jan 04 2017 Nick Miller <nick.miller@onyxpoint.com> - 5.0.1-0
 - Strong typed module
 - Updated for Puppet 4
+- Changed validate cmd to be valid
 
 * Thu Dec 01 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.1-0
 - Removed unnecessary pupmod-simp-rsync dependency

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class sudo {
     owner        => 'root',
     group        => 'root',
     mode         => '0440',
-    validate_cmd => '/usr/sbin/visudo -q -c -f',
+    validate_cmd => '/usr/sbin/visudo -q -c',
     require      => Package['sudo']
   }
 }


### PR DESCRIPTION
The syntax of the validate command was incorrect. The `-f` option
required a argument was was used incorrectly.

SIMP-2506 #close