### PR TITLE
(SIMP-1311) Enable proper validation of sudoers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Feb 03 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.2-0
+- Fixed the validation command on the concat resource to actually validate the
+  temp file prior to putting it in place
+
 * Thu Jan 05 2017 Nick Miller <nick.miller@onyxpoint.com> - 5.0.1-0
 - Added feature to add sudo::user_specification resources from hiera
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Feb 03 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.2-0
+* Fri Feb 03 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.1-0
 - Fixed the validation command on the concat resource to actually validate the
   temp file prior to putting it in place
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,7 @@ class sudo (
     owner        => 'root',
     group        => 'root',
     mode         => '0440',
-    validate_cmd => '/usr/sbin/visudo -q -c',
+    validate_cmd => '/usr/sbin/visudo -q -c -f %',
     require      => Package['sudo']
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.0.2",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",


### PR DESCRIPTION
The /etc/sudoers file was not being properly validated prior to being
laid down. This patch uses the pass-through validate_cmd capabilitiy of
the file resource to validate the new sudoers file before it is written
to the system.

SIMP-1311 #close