### PR TITLE
(SIMP-3613) sudo: Update to concat 3.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.3-0
+- Update concat version in metadata.json
+- Add concat dependency to build/rpm_metadata/requires
+
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.2-0
 - Confine puppet version in metadata.json
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,4 +1,6 @@
 Obsoletes: pupmod-sudo-test >= 0.0.1
+Requires: pupmod-puppetlabs-concat < 4.0.0-0
+Requires: pupmod-puppetlabs-concat >= 2.2.0-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
 Requires: pupmod-simp-simpcat < 7.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
- concat 3.0.0 is fully backward compatible with 2.x.
- Update concat version in metadata.json
- Add concat dependency to build/rpm_metadata/requires