### PR TITLE
(SIMP-4966) Add fqdn to default host list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Jun 20 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.5-0
+- Add both fqdn and hostname to user_specification entries by default
+
 * Fri Feb 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.4-0
 - Update upperbound on puppetlabs/concat version to < 5.0.0
 

--- a/manifests/user_specification.pp
+++ b/manifests/user_specification.pp
@@ -40,7 +40,7 @@
 define sudo::user_specification (
   Array[String[1]]         $user_list,
   Array[String[1]]         $cmnd,
-  Array[Simplib::Hostname] $host_list = [$facts['hostname']],
+  Array[Simplib::Hostname] $host_list = [$facts['hostname'], $facts['fqdn']],
   String[1]                $runas     = 'root',
   Boolean                  $passwd    = true,
   Boolean                  $doexec    = true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",

--- a/spec/defines/user_specification_spec.rb
+++ b/spec/defines/user_specification_spec.rb
@@ -16,7 +16,7 @@ describe 'sudo::user_specification' do
 
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe, jimbob, %foo    foo=(root) PASSWD:EXEC:SETENV: ifconfig\n\n")
+              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) PASSWD:EXEC:SETENV: ifconfig\n\n")
           end
         end
 
@@ -31,7 +31,7 @@ describe 'sudo::user_specification' do
 
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe, jimbob, %foo    foo=(root) NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n\n")
+              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n\n")
           end
         end
       end


### PR DESCRIPTION
Different applications expect different things when it comes to the host
list specified on a given host. Adding both the 'hostname' and 'fqdn'
will cover the expected bases by default.

SIMP-4966 #comment set sudo defaults reasonably