### PR TITLE
(SIMP-5095) Do not accept empty hostlist for sudo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Aug 20 2018 Jeanne Greulich jeanne.greulich@onyxpoint.com> - 5.0.6-0
+* Fri Aug 20 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.6-0
 - Added minmim size for hostlist so blank list was not accepted.
 
 * Wed Jun 20 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.5-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Aug 20 2018 Jeanne Greulich jeanne.greulich@onyxpoint.com> - 5.0.6-0
+- Added minmim size for hostlist so blank list was not accepted.
+
 * Wed Jun 20 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.5-0
 - Add both fqdn and hostname to user_specification entries by default
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Fri Aug 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.6-0
-- Added minmim size for hostlist so blank list was not accepted.
+- Added minimum size for hostlist so blank list was not accepted.
 
 * Wed Jun 20 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.5-0
 - Add both fqdn and hostname to user_specification entries by default

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Fri Aug 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.6-0
-- Added minimum size for hostlist so blank list was not accepted.
+- Added minimum size for sudo::user_specification::hostlist, because an
+  empty list is not permitted.
 
 * Wed Jun 20 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.5-0
 - Add both fqdn and hostname to user_specification entries by default

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Aug 20 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.6-0
+* Fri Aug 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.6-0
 - Added minmim size for hostlist so blank list was not accepted.
 
 * Wed Jun 20 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.5-0

--- a/manifests/user_specification.pp
+++ b/manifests/user_specification.pp
@@ -40,7 +40,7 @@
 define sudo::user_specification (
   Array[String[1]]         $user_list,
   Array[String[1]]         $cmnd,
-  Array[Simplib::Hostname] $host_list = [$facts['hostname'], $facts['fqdn']],
+  Array[Simplib::Hostname,1] $host_list = [$facts['hostname'], $facts['fqdn']],
   String[1]                $runas     = 'root',
   Boolean                  $passwd    = true,
   Boolean                  $doexec    = true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",

--- a/spec/defines/user_specification_spec.rb
+++ b/spec/defines/user_specification_spec.rb
@@ -34,6 +34,18 @@ describe 'sudo::user_specification' do
               .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n\n")
           end
         end
+
+        context 'with an empty host list' do
+          let(:params) {{
+            :user_list => ['joe','jimbob','%foo'],
+            :cmnd      => ['ifconfig', 'tcpdump'],
+            :hostlist  => []
+          }}
+
+          it do
+            is_expected.to raise_error(Puppet::Error)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
  - updated user_specification define to not accept an empty hostlist.
    It was resulting in a poorly formed entry.

SIMP-5095 #close
SIMP-5188 #close