### PR TITLE
(SIMP-5099) Replace all sudosh references

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Aug 24 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.7-0
+- Replaced all references to 'sudosh' with 'su' to reduce future confusion as
+  we move away from using sudosh.
+
 * Fri Aug 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.6-0
 - Added minimum size for sudo::user_specification::hostlist, because an
   empty list is not permitted.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,9 +6,9 @@
 #   Example:
 #     ---
 #     sudo::user_specifications:
-#       simp_sudosh:
+#       simp_su:_
 #         user_list: ['simp']
-#         cmnd: ['/usr/bin/sudosh']
+#         cmnd: ['/bin/su']
 #       users_yum_update:
 #         user_list:
 #           - '%users'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 #   Example:
 #     ---
 #     sudo::user_specifications:
-#       simp_su:_
+#       simp_su:
 #         user_list: ['simp']
 #         cmnd: ['/bin/su']
 #       users_yum_update:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -17,9 +17,9 @@ describe 'sudo' do
         context 'should create sudo::user_specification resources with an iterator' do
           context 'with properly formatted and complete yaml' do
             let(:hieradata) { 'sudo__user_specifications' }
-            it { is_expected.to create_sudo__user_specification('simp_sudosh').with({
+            it { is_expected.to create_sudo__user_specification('simp_su').with({
               :user_list => ['simp'],
-              :cmnd      => ['/usr/bin/sudosh'],
+              :cmnd      => ['/bin/su'],
             })}
             it { is_expected.to create_sudo__user_specification('users_yum_update').with({
               :user_list => ['%users'],

--- a/spec/fixtures/hieradata/sudo__user_specifications.yaml
+++ b/spec/fixtures/hieradata/sudo__user_specifications.yaml
@@ -1,8 +1,8 @@
 ---
 sudo::user_specifications:
-  simp_sudosh:
+  simp_su:
     user_list: ['simp']
-    cmnd: ['/usr/bin/sudosh']
+    cmnd: ['/bin/su']
   users_yum_update:
     user_list:
       - '%users'


### PR DESCRIPTION
Replaced all 'sudosh' references with 'su' to reduce future user and
developer confusion as we move away from using 'sudosh'