### PR TITLE
(SIMP-6640) Support additional options

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,14 +5,11 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.1      4.10.6   2.1.9  TBD
-# SIMP 6.2      4.10.12  2.1.9  TBD
-# SIMP 6.3      5.5.7    2.4.4  TBD***
-# PE 2018.1     5.5.8    2.4.4  2020-05 (LTS)***
+# SIMP 6.3      5.5.10   2.4.5  TBD***
+# PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 ---
 stages:
   - 'sanity'
@@ -65,18 +62,6 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_4: &pup_4
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.0'
-    MATRIX_RUBY_VERSION: '2.1'
-
-.pup_4_10: &pup_4_10
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.10.4'
-    MATRIX_RUBY_VERSION: '2.1'
-
 .pup_5: &pup_5
   image: 'ruby:2.4'
   variables:
@@ -84,21 +69,19 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_7: &pup_5_5_7
+.pup_5_5_10: &pup_5_5_10
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.7'
+    PUPPET_VERSION: '5.5.10'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
 .pup_6: &pup_6
-  allow_failure: true
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
-
 
 # Testing Environments
 #-----------------------------------------------------------------------
@@ -151,10 +134,6 @@ sanity_checks:
 # Linting
 #-----------------------------------------------------------------------
 
-pup4-lint:
-  <<: *pup_4
-  <<: *lint_tests
-
 pup5-lint:
   <<: *pup_5
   <<: *lint_tests
@@ -170,21 +149,10 @@ pup5-unit:
   <<: *pup_5
   <<: *unit_tests
 
-pup5.5.7-unit:
-  <<: *pup_5_5_7
-  <<: *unit_tests
-
-pup4.10-unit:
-  <<: *pup_4_10
+pup5.5.10-unit:
+  <<: *pup_5_5_10
   <<: *unit_tests
 
 pup6-unit:
   <<: *pup_6
   <<: *unit_tests
-
-# Acceptance tests
-# ==============================================================================
-# This module does not yet have acceptance tests.
-#
-# See: https://simp-project.atlassian.net/browse/SIMP-5632)
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,12 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.2      4.10     2.1.9  TBD
-# PE 2016.4     4.10     2.1.9  2018-12-31 (LTS)
-# PE 2017.3     5.3      2.4.4  2018-12-31
-# SIMP 6.3      5.5      2.4.4  TBD***
-# PE 2018.1     5.5      2.4.4  2020-05 (LTS)***
+# PE 2017.3     5.3      2.4.5  2018-12-31
+# SIMP 6.3      5.5      2.4.5  TBD***
+# PE 2018.1     5.5      2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 
 ---
 language: ruby
@@ -38,18 +35,16 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes
 
 jobs:
-  allow_failures:
-    - name: 'Latest Puppet 6.x (allowed to fail)'
-
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -62,21 +57,14 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 4.10 (SIMP 6.2, PE 2016.4)'
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.10.0"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
       name: 'Puppet 5.3 (PE 2017.3)'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.3.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      rvm: 2.4.4
+      rvm: 2.4.5
       name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
@@ -84,25 +72,26 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Latest Puppet 6.x (allowed to fail)'
+      name: 'Latest Puppet 6.x'
       rvm: 2.5.1
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.4
+      rvm: 2.4.5
       script:
         - true
       before_deploy:
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
         - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+
       deploy:
         - provider: releases
           api_key:
@@ -117,5 +106,4 @@ jobs:
             secure: "e9jul8wsW6DaKvxvMojPT8YZT4iV2CIUru5kxmdNT9lKpNi0lEDqcMGoDEjJaLiKxEiR5KlkoZw+lq8S+yGe4icurh66bksCcCGxBio/H9yB5PktMXqEbFzF5dOXfKjNWRT8u4hOQTCmdagqdnlzZzkOnFKjvBxFX0qpBSLoEI2+c5Ah0SAuTtIf13PWKtNYVkFXLO40+zZ2xR+mVu1lJGZ7v5tMYBcC2VTlajpRu0QLUKHfkbTuk9aokZDBSjX5CU388t9YxRIKelbjr0I3Ah4iuWrRWT1HMtKeYF1XWCvLqJ+pXJXL9pKnlzCnUnvsHTYhM//NiBklmHyLqFuKokkK/FUOWlN7ga0HAk8tkj1C5ixyXiwZ1kLpiCCNmd0TLXup5wmvDW2lfZFpTxKvCURRbrhbbH0md4vBb6k25D6ZcHkeblOSyZCrI3zKKFgyKI3dpBraEjUXZWI4Sljtoq7xv8qpo+lIE0zQuA2pkAkIQ6jCqO6CbjYkR7FR73uAMSh+eCdqyD9Az4wrX2R5pM588XI8qu+INTwrtF26du2KExWkukrDWKGtck+msqPSYE2uBixFJJBIonqvHzXsrM9bvxvp8slYCYhDDKQI2xut1Hi6rMxv3MVVFzYYEdTyNiKrBWgLnoIjjzxTEsMPOtDNXpiK83LKIYeKEg8oHxI="
           on:
             tags: true
-            rvm: 2.4.4
             condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Jun 12 2019 Steven Pritchard <steven.pritchard@onyxpoint.com> - 5.1.3-0
+- Allow additional options in sudo::user_specification
+
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.1.2-0
 - Expanded the upper limit of the concat and stdlib Puppet module versions
 - Updated URLs in the README.md

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
-* Wed Jun 12 2019 Steven Pritchard <steven.pritchard@onyxpoint.com> - 5.1.3-0
+* Wed Jun 12 2019 Steven Pritchard <steven.pritchard@onyxpoint.com> - 5.2.0-0
 - Allow additional options in sudo::user_specification
+- Add Puppet 6 support
+- Remove Puppet 4 support
+- Allow puppetlabs/stdlib < 7
 
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.1.2-0
 - Expanded the upper limit of the concat and stdlib Puppet module versions

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.2')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.6')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.8.3', '< 6.0'])
 end
 
 group :development do

--- a/manifests/user_specification.pp
+++ b/manifests/user_specification.pp
@@ -26,6 +26,9 @@
 # @param setenv
 #   Set SETENV in /etc/sudoers
 #
+# @param options
+#   Set additional options (such as SELinux role or type, date restrictions, or timeout)
+#
 # @example To create the following in /etc/sudoers:
 #   `simp, %simp_group    user2-dev1=(root) PASSWD:EXEC:SETENV: /bin/su root, /bin/su - root`
 #   Use the user_specification definition:
@@ -44,7 +47,8 @@ define sudo::user_specification (
   String[1]                $runas     = 'root',
   Boolean                  $passwd    = true,
   Boolean                  $doexec    = true,
-  Boolean                  $setenv    = true
+  Boolean                  $setenv    = true,
+  Hash                     $options   = {},
 ) {
   include '::sudo'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     },
     {
       "name": "simp/simplib",
@@ -51,7 +51,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     }
   ]
 }

--- a/spec/defines/user_specification_spec.rb
+++ b/spec/defines/user_specification_spec.rb
@@ -16,7 +16,7 @@ describe 'sudo::user_specification' do
 
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) PASSWD:EXEC:SETENV: ifconfig\n\n")
+              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root)  PASSWD:EXEC:SETENV: ifconfig\n\n")
           end
         end
 
@@ -31,7 +31,7 @@ describe 'sudo::user_specification' do
 
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n\n")
+              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root)  NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n\n")
           end
         end
 
@@ -44,6 +44,22 @@ describe 'sudo::user_specification' do
 
           it do
             is_expected.to raise_error(Puppet::Error)
+          end
+        end
+
+        context 'with role in options' do
+          let(:params) {{
+            :user_list => ['joe','jimbob','%foo'],
+            :cmnd      => ['ifconfig', 'tcpdump'],
+            :passwd    => false,
+            :doexec    => false,
+            :setenv    => false,
+            :options   => {'role' => 'unconfined_r'}
+          }}
+
+          it do
+            is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
+              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) ROLE=unconfined_r NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n\n")
           end
         end
       end

--- a/templates/uspec.erb
+++ b/templates/uspec.erb
@@ -17,7 +17,12 @@ if ['RedHat','CentOS','OracleLinux'].include?(@facts['operatingsystem'])
   else
     t_tag_spec.push('NOSETENV')
   end
+end
+
+opts = Array.new
+@options.each do |k,v|
+  opts.push("#{k.upcase}=#{v}")
 end -%>
 
-<%= Array(@user_list).join(', ') %>    <%= Array(@host_list).join(', ') %>=(<%= Array(@runas).join(', ') %>) <%= t_tag_spec.join(':') %>: <%= Array(@cmnd).join(', ') %>
+<%= Array(@user_list).join(', ') %>    <%= Array(@host_list).join(', ') %>=(<%= Array(@runas).join(', ') %>) <%= opts.join(" ") %> <%= t_tag_spec.join(':') %>: <%= Array(@cmnd).join(', ') %>
 


### PR DESCRIPTION
(SIMP-6640) Support additional options

Updated the sudoers template to allow additional options.

This would allow (for example) specifying `ROLE=unconfined_r` in sudoers
(by passing
```
options = {
    'role' => 'unconfined_r',
}
```
to the sudo::user_specification defined type) to eliminate the need to pass
the `-r unconfined_r` option to sudo.

SIMP-6640 #close