### PR TITLE
Removing (excess?) template whitespace

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Jun 09 2020 Arjen Zonneveld <arjenz@users.noreply.github.com> - 5.3.1-0
+- Fixed docs for user_list Array type
+
 * Tue Jun 09 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 5.3.0-0
 - Add parameters for sudo::default_entry and sudo::alias defined types
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",

--- a/spec/defines/alias_spec.rb
+++ b/spec/defines/alias_spec.rb
@@ -17,7 +17,7 @@ describe 'sudo::alias' do
           it { is_expected.to compile.with_all_deps }
           it {
             is_expected.to contain_concat__fragment("sudo_#{params[:alias_type]}_alias_#{title}").with_content(
-              "\nUser_Alias USER_ALIAS1 = millert, mikef\n\n"
+              "User_Alias USER_ALIAS1 = millert, mikef\n"
             )
           }
         end
@@ -33,7 +33,7 @@ describe 'sudo::alias' do
           it { is_expected.to compile.with_all_deps }
           it {
             is_expected.to contain_concat__fragment("sudo_#{params[:alias_type]}_alias_#{title}").with_content(
-              "#generic comment\n\nRunas_Alias RUNAS_ALIAS7 = millert, mikef\n\n"
+              "#generic comment\nRunas_Alias RUNAS_ALIAS7 = millert, mikef\n"
             )
           }
         end
@@ -50,7 +50,7 @@ describe 'sudo::alias' do
 
             it {
               is_expected.to contain_concat__fragment("sudo_#{params[:alias_type]}_alias_#{title}").with_content(
-                "#generic comment\n\nRunas_Alias RUNAS_ALL = ALL, !mikef, !#-1\n\n"
+                "#generic comment\nRunas_Alias RUNAS_ALL = ALL, !mikef, !#-1\n"
               )
             }
           end
@@ -59,7 +59,7 @@ describe 'sudo::alias' do
 
             it {
               is_expected.to contain_concat__fragment("sudo_#{params[:alias_type]}_alias_#{title}").with_content(
-                "#generic comment\n\nRunas_Alias RUNAS_ALL = ALL, !mikef\n\n"
+                "#generic comment\nRunas_Alias RUNAS_ALL = ALL, !mikef\n"
               )
             }
           end

--- a/spec/defines/default_entry_spec.rb
+++ b/spec/defines/default_entry_spec.rb
@@ -14,18 +14,18 @@ describe 'sudo::default_entry' do
           it { is_expected.to compile.with_all_deps }
           it do
             is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
-              .with_content("\nDefaults    first, second\n\n")
+              .with_content("Defaults    first, second\n")
           end
         end
 
         context 'def_type = host and target specified' do
-          let(:params) { {:content => ['first', 'second'], :def_type => 'host', 
+          let(:params) { {:content => ['first', 'second'], :def_type => 'host',
             :target => 'some_host_target'} }
 
           it { is_expected.to compile.with_all_deps }
           it do
             is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
-              .with_content("\nDefaults@some_host_target    first, second\n\n")
+              .with_content("Defaults@some_host_target    first, second\n")
           end
         end
 
@@ -36,7 +36,7 @@ describe 'sudo::default_entry' do
           it { is_expected.to compile.with_all_deps }
           it do
             is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
-              .with_content("\nDefaults!some_cmnd_target    first, second\n\n")
+              .with_content("Defaults!some_cmnd_target    first, second\n")
           end
         end
 
@@ -46,7 +46,7 @@ describe 'sudo::default_entry' do
           it { is_expected.to compile.with_all_deps }
           it do
             is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
-              .with_content("\nDefaults:    first, second\n\n")
+              .with_content("Defaults:    first, second\n")
           end
         end
 
@@ -56,7 +56,7 @@ describe 'sudo::default_entry' do
           it { is_expected.to compile.with_all_deps }
           it do
             is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
-              .with_content("\nDefaults>    first, second\n\n")
+              .with_content("Defaults>    first, second\n")
           end
         end
 
@@ -66,7 +66,7 @@ describe 'sudo::default_entry' do
           it { is_expected.to compile.with_all_deps }
           it do
             is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
-              .with_content("\nDefaults!    first, second\n\n")
+              .with_content("Defaults!    first, second\n")
           end
         end
         # Test cve 2019-14287 mitigation
@@ -77,14 +77,14 @@ describe 'sudo::default_entry' do
             let(:facts) { os_facts.merge( { :sudo_version => '1.8.0' })}
              it do
                is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
-                 .with_content("\nDefaults>    %ALL, !%wheel, !%#-1\n\n")
+                 .with_content("Defaults>    %ALL, !%wheel, !%#-1\n")
              end
           end
           context 'sudo version >= 1.8.28' do
             let(:facts) { os_facts.merge( { :sudo_version => '1.8.30' })}
              it do
                is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
-                 .with_content("\nDefaults>    %ALL, !%wheel\n\n")
+                 .with_content("Defaults>    %ALL, !%wheel\n")
              end
           end
         end

--- a/spec/defines/user_specification_spec.rb
+++ b/spec/defines/user_specification_spec.rb
@@ -16,7 +16,7 @@ describe 'sudo::user_specification' do
 
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root)  PASSWD:EXEC:SETENV: ifconfig\n\n")
+              .with_content("joe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root)  PASSWD:EXEC:SETENV: ifconfig\n")
           end
         end
 
@@ -31,7 +31,7 @@ describe 'sudo::user_specification' do
 
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root)  NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n\n")
+              .with_content("joe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root)  NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n")
           end
         end
 
@@ -59,12 +59,12 @@ describe 'sudo::user_specification' do
 
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) ROLE=unconfined_r NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n\n")
+              .with_content("joe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) ROLE=unconfined_r NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n")
           end
         end
         #test for cve_2019-14287 mitigation
         context 'with  sudo version <  1.8.28' do
-          let(:facts) { 
+          let(:facts) {
             os_facts.merge({
               'sudo_version' => '1.8.10'
           })}
@@ -78,11 +78,11 @@ describe 'sudo::user_specification' do
           }}
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe    #{facts[:hostname]}, #{facts[:fqdn]}=(ALL, !#-1)  NOPASSWD:NOEXEC:NOSETENV: cat\n\n")
+              .with_content("joe    #{facts[:hostname]}, #{facts[:fqdn]}=(ALL, !#-1)  NOPASSWD:NOEXEC:NOSETENV: cat\n")
           end
         end
         context 'with  sudo version >  1.8.28' do
-          let(:facts) { 
+          let(:facts) {
             os_facts.merge({
               'sudo_version' => '1.8.30'
           })}
@@ -96,7 +96,7 @@ describe 'sudo::user_specification' do
           }}
           it do
             is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
-              .with_content("\njoe    #{facts[:hostname]}, #{facts[:fqdn]}=(ALL)  NOPASSWD:NOEXEC:NOSETENV: cat\n\n")
+              .with_content("joe    #{facts[:hostname]}, #{facts[:fqdn]}=(ALL)  NOPASSWD:NOEXEC:NOSETENV: cat\n")
           end
         end
       end

--- a/templates/alias.erb
+++ b/templates/alias.erb
@@ -1,6 +1,4 @@
 <% if @comment -%>
 #<%= @comment %>
 <% end -%>
-
 <%= @alias_type.capitalize %>_Alias <%= @name.upcase %> = <%= Array(@_content).join(', ') %>
-

--- a/templates/defaults.erb
+++ b/templates/defaults.erb
@@ -9,10 +9,8 @@
       symbol = '!'
     else
       symbol = ''
-    end -%>
-<% if @target
+    end
+   if @target
     symbol = "#{symbol}#{@target}"
 end -%>
-
 Defaults<%= symbol %>    <%= Array(@_content).join(', ') %>
-

--- a/templates/uspec.erb
+++ b/templates/uspec.erb
@@ -1,5 +1,6 @@
-<% t_tag_spec = Array.new -%>
-<% if @passwd
+<%
+t_tag_spec = Array.new
+if @passwd
     t_tag_spec.push('PASSWD')
 else
     t_tag_spec.push('NOPASSWD')
@@ -23,6 +24,4 @@ opts = Array.new
 @options.each do |k,v|
   opts.push("#{k.upcase}=#{v}")
 end -%>
-
 <%= Array(@user_list).join(', ') %>    <%= Array(@host_list).join(', ') %>=(<%= Array(@_runas).join(', ') %>) <%= opts.join(" ") %> <%= t_tag_spec.join(':') %>: <%= Array(@cmnd).join(', ') %>
-


### PR DESCRIPTION
Hey, Trevor et al.

By default, the sudo templates result in lines with whitespace before and after each defaults, alias, and user entry. So basically one line of content, two lines of whitespace, one line of content, ...

Probably a matter of opinion on how much whitespace there should be, but this PR clears out the whitespace entirely, which makes diffs easier to read (at least for me). Feel free to reject, modify, or approve as is. Thanks.