### PR TITLE
Finalize RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -117,6 +117,7 @@ jobs:
             puppet_version: '~> 8.0'
             ruby_version: 3.1
             experimental: true
+      fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
@@ -129,7 +130,6 @@ jobs:
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
         continue-on-error: ${{matrix.puppet.experimental}}
-        fail-fast: false
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 /junit
 /log
 /doc
+/Gemfile.lock

--- a/manifests/user_specification.pp
+++ b/manifests/user_specification.pp
@@ -43,7 +43,7 @@
 define sudo::user_specification (
   Array[String[1]]                    $user_list,
   Array[String[1]]                    $cmnd,
-  Array[Simplib::Hostname,1]          $host_list  = [$facts['hostname'], $facts['fqdn']],
+  Array[Simplib::Hostname,1]          $host_list  = [$facts['networking']['hostname'], $facts['networking']['fqdn']],
   Variant[String[1],Array[String[1]]] $runas      = ['root'],
   Boolean                             $passwd     = true,
   Boolean                             $doexec     = true,


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.