### PR TITLE
Reduce blast radius and ship simp:defaults profile (7.0.0)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 ---
 fixtures:
   repositories:
-    concat: https://github.com/simp/puppetlabs-concat.git
+    compliance_engine:
+      repo: https://github.com/simp/rubygem-simp-compliance_engine.git
+      ref: '1.0.0'
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
   symlinks:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 # Read everything in fixtures
 /spec/fixtures/*
 # Un-ignore hieradata
+!/spec/fixtures/hieradata/
 !/spec/fixtures/hieradata/*
 # Except this one, which is auto-generated
 /spec/fixtures/hieradata/hiera.yaml

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+* Tue Jun 17 2026 Steven Pritchard <steven.pritchard@gmail.com> - 7.0.0
+- Reduce blast radius (BREAKING CHANGE): a bare `include sudo` now installs
+  the `sudo` package and does nothing else
+  - The module no longer manages (or blanks) the shared `/etc/sudoers`
+  - Managed aliases, defaults, user specifications, and `#includedir` lines
+    are now written as individual drop-in files under `/etc/sudoers.d/`
+    (configurable via the new `sudo::content_dir` parameter)
+  - Dropped the `puppetlabs/concat` dependency; sudoers content is no longer
+    validated with `visudo` (cross-file alias references cannot be validated
+    in isolation)
+  - `sudo::package_ensure` no longer follows `simp_options::package_ensure`
+    (defaults to `installed`)
+- Ship a `simp:defaults` compliance_engine profile that restores the
+  pre-refactor defaults; activate with
+  `compliance_engine::enforcement: [simp:defaults]`
+
 * Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 6.0.0
 - Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
 - Point `issues_url` at GitHub Issues

--- a/README.md
+++ b/README.md
@@ -21,14 +21,58 @@
 
 ## Module Description
 
-Constructs a sudoers file based on configuration aliases, defaults, and user
-specifications.
+Manages sudo configuration through aliases, defaults, and user
+specifications, written as individual drop-in files under `/etc/sudoers.d/`.
 
-## Setup
+## Breaking changes in 7.0.0
+
+Version 7.0.0 reduces the "blast radius" of this module. **A bare
+`include sudo` now installs the `sudo` package and does nothing else.** In
+particular:
+
+- The module **no longer manages `/etc/sudoers`**. Previously a bare
+  `include sudo` declared a `concat` resource for `/etc/sudoers`, which took
+  whole-file ownership of that shared file and, with no entries configured,
+  *blanked* it (wiping the OS-shipped `Defaults` and `#includedir`). The OS
+  `/etc/sudoers` is now left untouched.
+- All managed entries (`sudo::alias`, `sudo::default_entry`,
+  `sudo::user_specification`, and the `#includedir` lines from
+  `sudo::include_dir`) are now written as **individual files under
+  `/etc/sudoers.d/`** (configurable via the `sudo::content_dir` parameter),
+  which sudo reads via its default `#includedir`. File names carry a
+  numeric prefix so the previous relative ordering (aliases, then defaults,
+  then user specifications) is preserved.
+- The **`puppetlabs/concat` dependency has been removed.** As a consequence,
+  sudoers content is **no longer validated with `visudo`** before being
+  written. A `sudo::user_specification` may reference a `User_Alias` or
+  `Cmnd_Alias` defined in a separate file, and such cross-file references
+  cannot be validated in isolation, so per-file validation was dropped.
+- `sudo::package_ensure` no longer follows `simp_options::package_ensure`;
+  it defaults to `installed`.
+
+### Recovery paths
+
+1. **Per parameter:** set the parameters you need explicitly (the defines
+   work exactly as before — they simply write to `/etc/sudoers.d/` now).
+2. **`simp:defaults` profile:** enable the shipped compliance_engine
+   profile to restore the pre-refactor defaults stack-wide:
+
+   ```yaml
+   compliance_engine::enforcement:
+     - simp:defaults
+   ```
+
+   For sudo this restores `sudo::package_ensure: installed`. A value set
+   explicitly in your own Hiera always wins over the profile.
+
+   > **Note:** the profile restores parameter *values* only. The former
+   > whole-file management of `/etc/sudoers` was structurally removed (there
+   > is no parameter for it) and is intentionally **not** restorable.
 
 ### What sudo affects
 
-sudo will ensure the sudo package is installed, and will manage /etc/sudoers.
+sudo ensures the `sudo` package is installed and, when entries are
+configured, writes them as drop-in files under `/etc/sudoers.d/`.
 
 ### Setup Requirements
 
@@ -37,7 +81,7 @@ into your modulepath
 
 ### Beginning with sudo
 
-To create the default SIMP /etc/sudoers file:
+A bare include installs the package only:
 
 ```puppet
 include 'sudo'

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -42,6 +42,7 @@ The following parameters are available in the `sudo` class:
 * [`user_specifications`](#-sudo--user_specifications)
 * [`include_dirs`](#-sudo--include_dirs)
 * [`package_ensure`](#-sudo--package_ensure)
+* [`content_dir`](#-sudo--content_dir)
 * [`default_entries`](#-sudo--default_entries)
 * [`aliases`](#-sudo--aliases)
 
@@ -79,11 +80,23 @@ Default value: `[]`
 
 ##### <a name="-sudo--package_ensure"></a>`package_ensure`
 
-Data type: `String`
+Data type: `String[1]`
 
 The ensure status of packages to be managed
 
-Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
+Default value: `'installed'`
+
+##### <a name="-sudo--content_dir"></a>`content_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+The directory under which this module writes its managed sudoers
+drop-in files. Defaults to `/etc/sudoers.d`, which sudo reads via the
+distribution's `#includedir` directive. Each managed entry is written as
+its own file here, so the shared `/etc/sudoers` is never owned by this
+module.
+
+Default value: `'/etc/sudoers.d'`
 
 ##### <a name="-sudo--default_entries"></a>`default_entries`
 

--- a/SIMP/compliance_profiles/checks.yaml
+++ b/SIMP/compliance_profiles/checks.yaml
@@ -1,0 +1,8 @@
+---
+version: 2.0.0
+checks:
+  simp:defaults.sudo.package_ensure:
+    type: puppet-class-parameter
+    settings:
+      parameter: sudo::package_ensure
+      value: installed

--- a/SIMP/compliance_profiles/profile-simp_defaults.yaml
+++ b/SIMP/compliance_profiles/profile-simp_defaults.yaml
@@ -1,0 +1,6 @@
+---
+version: 2.0.0
+profiles:
+  simp:defaults:
+    checks:
+      simp:defaults.sudo.package_ensure: true

--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -40,9 +40,13 @@ define sudo::alias (
     $_content = sudo::update_runas_list($content)
   }
 
-  concat::fragment { "sudo_${alias_type}_alias_${name}":
-    order   => $order,
-    target  => '/etc/sudoers',
+  $_filename = sprintf('%04d_%s_alias_%s', $order, $alias_type, regsubst($name, '[^0-9A-Za-z_-]', '_', 'G'))
+
+  file { "${sudo::content_dir}/${_filename}":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
     content => epp(
       "${module_name}/alias.epp",
       {
@@ -52,5 +56,6 @@ define sudo::alias (
         'name'       => $name,
       },
     ),
+    require => Package['sudo'],
   }
 }

--- a/manifests/default_entry.pp
+++ b/manifests/default_entry.pp
@@ -56,9 +56,13 @@ define sudo::default_entry (
     $_content = sudo::update_runas_list($content)
   }
 
-  concat::fragment { "sudo_default_entry_${name}":
-    order   => 80,
-    target  => '/etc/sudoers',
+  $_filename = sprintf('%04d_default_%s', 80, regsubst($name, '[^0-9A-Za-z_-]', '_', 'G'))
+
+  file { "${sudo::content_dir}/${_filename}":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
     content => epp(
       "${module_name}/defaults.epp",
       {
@@ -67,5 +71,6 @@ define sudo::default_entry (
         'def_type' => $def_type,
       },
     ),
+    require => Package['sudo'],
   }
 }

--- a/manifests/include_dir.pp
+++ b/manifests/include_dir.pp
@@ -17,9 +17,14 @@ define sudo::include_dir (
     recurse => true,
   }
 
-  concat::fragment { "sudo_include_dir_${include_dir}":
-    order   => 1000,
-    target  => '/etc/sudoers',
+  $_filename = sprintf('%04d_includedir_%s', 1000, regsubst($include_dir, '[^0-9A-Za-z_-]', '_', 'G'))
+
+  file { "${sudo::content_dir}/${_filename}":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
     content => "#includedir ${include_dir}\n",
+    require => Package['sudo'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,26 +24,26 @@
 #
 # @param package_ensure The ensure status of packages to be managed
 #
+# @param content_dir
+#   The directory under which this module writes its managed sudoers
+#   drop-in files. Defaults to `/etc/sudoers.d`, which sudo reads via the
+#   distribution's `#includedir` directive. Each managed entry is written as
+#   its own file here, so the shared `/etc/sudoers` is never owned by this
+#   module.
+#
 # @author https://github.com/simp/pupmod-simp-sudo/graphs/contributors
 #
 class sudo (
   Hash                        $user_specifications = {},
   Hash                        $default_entries     = {},
   Hash                        $aliases             = {},
-  String                      $package_ensure      = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  String[1]                   $package_ensure      = 'installed',
   Array[Stdlib::Absolutepath] $include_dirs        = [],
+  Stdlib::Absolutepath        $content_dir         = '/etc/sudoers.d',
 ) {
 
   package { 'sudo':
     ensure => $package_ensure
-  }
-
-  concat { '/etc/sudoers':
-    owner        => 'root',
-    group        => 'root',
-    mode         => '0440',
-    validate_cmd => '/usr/sbin/visudo -q -c -f %',
-    require      => Package['sudo']
   }
 
   $user_specifications.each |$spec, $options| {

--- a/manifests/user_specification.pp
+++ b/manifests/user_specification.pp
@@ -59,9 +59,13 @@ define sudo::user_specification (
     $_runas =  sudo::update_runas_list($runas)
   }
 
-  concat::fragment { "sudo_user_specification_${name}":
-    order   => 90,
-    target  => '/etc/sudoers',
+  $_filename = sprintf('%04d_uspec_%s', 90, regsubst($name, '[^0-9A-Za-z_-]', '_', 'G'))
+
+  file { "${sudo::content_dir}/${_filename}":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
     content => epp(
       "${module_name}/uspec.epp",
       {
@@ -75,5 +79,6 @@ define sudo::user_specification (
         'options'   => $options,
       },
     ),
+    require => Package['sudo'],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudo",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "author": "SIMP Team",
   "summary": "Manage sudo",
   "license": "Apache-2.0",
@@ -12,10 +12,6 @@
     "sudo"
   ],
   "dependencies": [
-    {
-      "name": "puppetlabs/concat",
-      "version_requirement": ">= 6.4.0 < 10.0.0"
-    },
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 8.0.0 < 10.0.0"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,9 +9,21 @@ describe 'sudo' do
         end
 
         context 'with default parameters' do
+          # A bare `include sudo` must install the package and do nothing
+          # else -- it must not take ownership of (or blank) /etc/sudoers,
+          # and must not drop any files into /etc/sudoers.d.
+          it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('sudo') }
-          it { is_expected.to contain_package('sudo') }
-          it { is_expected.to contain_concat('/etc/sudoers') }
+          it { is_expected.to contain_package('sudo').with_ensure('installed') }
+          it { is_expected.not_to contain_concat('/etc/sudoers') }
+          it { is_expected.not_to contain_file('/etc/sudoers') }
+
+          it 'declares no resources under /etc/sudoers.d' do
+            files = catalogue.resources.select do |r|
+              r.type == 'File' && r[:path].to_s.start_with?('/etc/sudoers.d')
+            end
+            expect(files).to be_empty
+          end
         end
 
         context 'should create sudo::user_specification resources with an iterator' do

--- a/spec/classes/sudo_simp_defaults_profile_spec.rb
+++ b/spec/classes/sudo_simp_defaults_profile_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+# Validates the shipped `simp:defaults` compliance_engine profile. Enabling
+# `compliance_engine::enforcement: [simp:defaults]` must restore the
+# pre-refactor module defaults, while an explicit site-Hiera value must still
+# win over the profile (the profile sits at *middle* Hiera priority).
+describe 'sudo' do
+  # Wire in the compliance_engine `lookup_key` backend, which the module's own
+  # hiera.yaml does not provide.
+  let(:hiera_config) do
+    File.expand_path('../fixtures/hieradata/hiera_compliance_engine.yaml', __dir__)
+  end
+
+  context 'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        context 'with simp:defaults enforced' do
+          let(:facts) { os_facts.merge(custom_hiera: 'simp_defaults_enforced') }
+
+          it { is_expected.to compile.with_all_deps }
+
+          # package_ensure is the one default the refactor moved off of
+          # simp_options; the profile restores it to its pre-refactor value.
+          it { is_expected.to contain_package('sudo').with_ensure('installed') }
+        end
+
+        context 'with simp:defaults enforced and an explicit site override' do
+          let(:facts) { os_facts.merge(custom_hiera: 'simp_defaults_with_override') }
+
+          it { is_expected.to compile.with_all_deps }
+
+          # The override (sudo::package_ensure: latest) must beat the profile,
+          # proving the profile sits below site Hiera, not above it.
+          it { is_expected.to contain_package('sudo').with_ensure('latest') }
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/alias_spec.rb
+++ b/spec/defines/alias_spec.rb
@@ -17,7 +17,7 @@ describe 'sudo::alias' do
 
           it { is_expected.to compile.with_all_deps }
           it {
-            is_expected.to contain_concat__fragment("sudo_#{params[:alias_type]}_alias_#{title}").with_content(
+            is_expected.to contain_file("/etc/sudoers.d/0010_#{params[:alias_type]}_alias_#{title}").with_content(
               "User_Alias USER_ALIAS1 = millert, mikef\n",
             )
           }
@@ -35,7 +35,7 @@ describe 'sudo::alias' do
 
           it { is_expected.to compile.with_all_deps }
           it {
-            is_expected.to contain_concat__fragment("sudo_#{params[:alias_type]}_alias_#{title}").with_content(
+            is_expected.to contain_file("/etc/sudoers.d/0010_#{params[:alias_type]}_alias_#{title}").with_content(
               "#generic comment\nRunas_Alias RUNAS_ALIAS7 = millert, mikef\n",
             )
           }
@@ -55,7 +55,7 @@ describe 'sudo::alias' do
             let(:facts) { os_facts.merge({ sudo_version: '1.8.18' }) }
 
             it {
-              is_expected.to contain_concat__fragment("sudo_#{params[:alias_type]}_alias_#{title}").with_content(
+              is_expected.to contain_file("/etc/sudoers.d/0010_#{params[:alias_type]}_alias_#{title}").with_content(
                 "#generic comment\nRunas_Alias RUNAS_ALL = ALL, !mikef, !#-1\n",
               )
             }
@@ -64,7 +64,7 @@ describe 'sudo::alias' do
             let(:facts) { os_facts.merge({ sudo_version: '1.8.28' }) }
 
             it {
-              is_expected.to contain_concat__fragment("sudo_#{params[:alias_type]}_alias_#{title}").with_content(
+              is_expected.to contain_file("/etc/sudoers.d/0010_#{params[:alias_type]}_alias_#{title}").with_content(
                 "#generic comment\nRunas_Alias RUNAS_ALL = ALL, !mikef\n",
               )
             }

--- a/spec/defines/default_entry_spec.rb
+++ b/spec/defines/default_entry_spec.rb
@@ -13,7 +13,7 @@ describe 'sudo::default_entry' do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0080_default_#{title}")
               .with_content("Defaults    first, second\n")
           end
         end
@@ -29,7 +29,7 @@ describe 'sudo::default_entry' do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0080_default_#{title}")
               .with_content("Defaults@some_host_target    first, second\n")
           end
         end
@@ -45,7 +45,7 @@ describe 'sudo::default_entry' do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0080_default_#{title}")
               .with_content("Defaults!some_cmnd_target    first, second\n")
           end
         end
@@ -55,7 +55,7 @@ describe 'sudo::default_entry' do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0080_default_#{title}")
               .with_content("Defaults:    first, second\n")
           end
         end
@@ -65,7 +65,7 @@ describe 'sudo::default_entry' do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0080_default_#{title}")
               .with_content("Defaults>    first, second\n")
           end
         end
@@ -75,7 +75,7 @@ describe 'sudo::default_entry' do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0080_default_#{title}")
               .with_content("Defaults!    first, second\n")
           end
         end
@@ -87,7 +87,7 @@ describe 'sudo::default_entry' do
             let(:facts) { os_facts.merge({ sudo_version: '1.8.0' }) }
 
             it do
-              is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
+              is_expected.to create_file("/etc/sudoers.d/0080_default_#{title}")
                 .with_content("Defaults>    %ALL, !%wheel, !%#-1\n")
             end
           end
@@ -95,7 +95,7 @@ describe 'sudo::default_entry' do
             let(:facts) { os_facts.merge({ sudo_version: '1.8.30' }) }
 
             it do
-              is_expected.to create_concat__fragment("sudo_default_entry_#{title}")
+              is_expected.to create_file("/etc/sudoers.d/0080_default_#{title}")
                 .with_content("Defaults>    %ALL, !%wheel\n")
             end
           end

--- a/spec/defines/include_dir_spec.rb
+++ b/spec/defines/include_dir_spec.rb
@@ -23,7 +23,7 @@ describe 'sudo::include_dir' do
                   group:   'root',
                   recurse: true,
                 )
-            is_expected.to create_concat__fragment('sudo_include_dir_/etc/sudoers.d')
+            is_expected.to create_file('/etc/sudoers.d/1000_includedir__etc_sudoers_d')
               .with_content("#includedir /etc/sudoers.d\n")
           end
         end

--- a/spec/defines/user_specification_spec.rb
+++ b/spec/defines/user_specification_spec.rb
@@ -17,7 +17,7 @@ describe 'sudo::user_specification' do
           end
 
           it do
-            is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0090_uspec_#{title}")
               .with_content("joe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root)  PASSWD:EXEC:SETENV: ifconfig\n")
           end
         end
@@ -34,7 +34,7 @@ describe 'sudo::user_specification' do
           end
 
           it do
-            is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0090_uspec_#{title}")
               .with_content("joe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root)  NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n")
           end
         end
@@ -66,7 +66,7 @@ describe 'sudo::user_specification' do
           end
 
           it do
-            is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0090_uspec_#{title}")
               .with_content("joe, jimbob, %foo    #{facts[:hostname]}, #{facts[:fqdn]}=(root) ROLE=unconfined_r NOPASSWD:NOEXEC:NOSETENV: ifconfig, tcpdump\n")
           end
         end
@@ -89,7 +89,7 @@ describe 'sudo::user_specification' do
           end
 
           it do
-            is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0090_uspec_#{title}")
               .with_content("joe    #{facts[:hostname]}, #{facts[:fqdn]}=(ALL, !#-1)  NOPASSWD:NOEXEC:NOSETENV: cat\n")
           end
         end
@@ -111,7 +111,7 @@ describe 'sudo::user_specification' do
           end
 
           it do
-            is_expected.to create_concat__fragment("sudo_user_specification_#{title}")
+            is_expected.to create_file("/etc/sudoers.d/0090_uspec_#{title}")
               .with_content("joe    #{facts[:hostname]}, #{facts[:fqdn]}=(ALL)  NOPASSWD:NOEXEC:NOSETENV: cat\n")
           end
         end

--- a/spec/fixtures/hieradata/hiera_compliance_engine.yaml
+++ b/spec/fixtures/hieradata/hiera_compliance_engine.yaml
@@ -1,0 +1,12 @@
+---
+version: 5
+defaults:
+  data_hash: yaml_data
+  datadir: '.'
+hierarchy:
+  - name: "Custom Test Hiera"
+    path: "%{custom_hiera}.yaml"
+  - name: "Common"
+    path: default.yaml
+  - name: "Compliance Engine"
+    lookup_key: "compliance_engine::enforcement"

--- a/spec/fixtures/hieradata/simp_defaults_enforced.yaml
+++ b/spec/fixtures/hieradata/simp_defaults_enforced.yaml
@@ -1,0 +1,3 @@
+---
+compliance_engine::enforcement:
+  - simp:defaults

--- a/spec/fixtures/hieradata/simp_defaults_with_override.yaml
+++ b/spec/fixtures/hieradata/simp_defaults_with_override.yaml
@@ -1,0 +1,4 @@
+---
+compliance_engine::enforcement:
+  - simp:defaults
+sudo::package_ensure: latest


### PR DESCRIPTION
## Overview

Applies the SIMP "reduce blast radius" refactor to `pupmod-simp-sudo` (**6.0.0 → 7.0.0**), then ships a matching `simp:defaults` compliance_engine profile. Same pattern as libreswan (#123) and aide (#160/#165).

**Content mechanism (deliberate design choice):** one file per entry, **no `concat`**. Each `sudo::*` define writes its own drop-in file under `/etc/sudoers.d/`; the `puppetlabs/concat` dependency is dropped entirely.

## ⚠️ Breaking changes (7.0.0)

A bare `include sudo` now installs the `sudo` package and **does nothing else**.

- **No longer manages `/etc/sudoers`.** Previously a bare include declared a `concat` for `/etc/sudoers`, taking whole-file ownership and — with no entries configured — *blanking* it (wiping the OS-shipped `Defaults` and `#includedir`). The OS file is now left untouched.
- **Entries become drop-in files** under `/etc/sudoers.d/` (configurable via the new `sudo::content_dir` parameter). Numeric filename prefixes (`0010_*alias*`, `0080_default_*`, `0090_uspec_*`, `1000_includedir_*`) preserve the prior relative ordering via sudo's sorted `#includedir`; titles are sanitized because sudo ignores include-dir files containing a `.`.
- **`puppetlabs/concat` dependency removed.** As a consequence, sudoers content is **no longer validated with `visudo`** before being written — a `sudo::user_specification` may reference a `User_Alias`/`Cmnd_Alias` defined in a separate file, and such cross-file references can't be validated in isolation.
- **`sudo::package_ensure`** no longer follows `simp_options::package_ensure` (defaults to `installed`).

### Recovery paths
1. Set the parameters you need explicitly (defines work exactly as before — they just write to `/etc/sudoers.d/` now).
2. Enable the shipped profile: `compliance_engine::enforcement: [simp:defaults]` (restores `package_ensure: installed`). Site Hiera always outranks the profile. The former whole-file `/etc/sudoers` management is structurally gone and intentionally **not** restorable.

## `simp:defaults` profile

Intentionally minimal — sudo has no `simp_options` coupling beyond `package_ensure`. Ships `SIMP/compliance_profiles/{profile-simp_defaults,checks}.yaml` plus the spec + compliance_engine hiera fixtures. `metadata.json` gets **no** compliance_engine dependency.

## Testing

Run in a `ruby:3.2` container (host Ruby 4.0.1 is too new for `pdk`):

- `rake spec`: **714 examples, 0 failures** — rewritten bare-include specs assert no `/etc/sudoers` and no `/etc/sudoers.d` resources; define + profile specs updated.
- `rake lint`, `syntax`, `metadata_lint`, `rubocop`: all clean.
- `REFERENCE.md` regenerated (100% documented).
- Separately verified the compliance_engine chain end-to-end: temporarily set the profile value to `latest` and confirmed enforcement injected it across all 14 supported OSes, then reverted.

## Review notes

- **Validation safety is reduced** — the direct trade-off of the no-`concat` approach. A typo'd entry can no longer be caught before write.
- Draft pending review of the validation trade-off and the `/etc/sudoers` → `/etc/sudoers.d/` behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
